### PR TITLE
Changes HTTP verbs enum to lower case (for Moya 8.0.0-beta.3)

### DIFF
--- a/Sources/Route.swift
+++ b/Sources/Route.swift
@@ -13,44 +13,44 @@ import Moya
 /// Example:
 ///
 /// ```
-/// .GET("/me")
+/// .get("/me")
 /// ```
 public enum Route {
-  case GET(String)
-  case POST(String)
-  case PUT(String)
-  case DELETE(String)
-  case OPTIONS(String)
-  case HEAD(String)
-  case PATCH(String)
-  case TRACE(String)
-  case CONNECT(String)
+  case get(String)
+  case post(String)
+  case put(String)
+  case delete(String)
+  case options(String)
+  case head(String)
+  case patch(String)
+  case trace(String)
+  case connect(String)
 
   public var path: String {
     switch self {
-    case .GET(let path): return path
-    case .POST(let path): return path
-    case .PUT(let path): return path
-    case .DELETE(let path): return path
-    case .OPTIONS(let path): return path
-    case .HEAD(let path): return path
-    case .PATCH(let path): return path
-    case .TRACE(let path): return path
-    case .CONNECT(let path): return path
+    case .get(let path): return path
+    case .post(let path): return path
+    case .put(let path): return path
+    case .delete(let path): return path
+    case .options(let path): return path
+    case .head(let path): return path
+    case .patch(let path): return path
+    case .trace(let path): return path
+    case .connect(let path): return path
     }
   }
 
   public var method: Moya.Method {
     switch self {
-    case .GET: return .GET
-    case .POST: return .POST
-    case .PUT: return .PUT
-    case .DELETE: return .DELETE
-    case .OPTIONS: return .OPTIONS
-    case .HEAD: return .HEAD
-    case .PATCH: return .PATCH
-    case .TRACE: return .TRACE
-    case .CONNECT: return .CONNECT
+    case .get: return .get
+    case .post: return .post
+    case .put: return .put
+    case .delete: return .delete
+    case .options: return .options
+    case .head: return .head
+    case .patch: return .patch
+    case .trace: return .trace
+    case .connect: return .connect
     }
   }
 }

--- a/Sources/SugarTargetType.swift
+++ b/Sources/SugarTargetType.swift
@@ -17,7 +17,7 @@ public protocol SugarTargetType: TargetType {
   ///
   /// ```
   /// var route: Route {
-  ///   return .GET("/me")
+  ///   return .get("/me")
   /// }
   /// ```
   var route: Route { get }

--- a/Tests/GitHubAPI.swift
+++ b/Tests/GitHubAPI.swift
@@ -22,13 +22,13 @@ enum GitHubAPI: SugarTargetType, Then {
   var route: Route {
     switch self {
     case .userRepos(let owner):
-      return .GET("/users/\(owner)/repos")
+      return .get("/users/\(owner)/repos")
 
     case .createIssue(let owner, let repo, _, _):
-      return .POST("/repos/\(owner)/\(repo)/issues")
+      return .post("/repos/\(owner)/\(repo)/issues")
 
     case .editIssue(let owner, let repo, let number, _, _):
-      return .PATCH("/repos/\(owner)/\(repo)/issues/\(number)")
+      return .patch("/repos/\(owner)/\(repo)/issues/\(number)")
     }
   }
 

--- a/Tests/RouteTests.swift
+++ b/Tests/RouteTests.swift
@@ -14,27 +14,27 @@ import MoyaSugar
 class MoyaSugarTests: XCTestCase {
 
   func testRouteMethod() {
-    XCTAssertEqual(Route.GET("/path").method, Moya.Method.GET)
-    XCTAssertEqual(Route.POST("/path").method, Moya.Method.POST)
-    XCTAssertEqual(Route.PUT("/path").method, Moya.Method.PUT)
-    XCTAssertEqual(Route.DELETE("/path").method, Moya.Method.DELETE)
-    XCTAssertEqual(Route.OPTIONS("/path").method, Moya.Method.OPTIONS)
-    XCTAssertEqual(Route.HEAD("/path").method, Moya.Method.HEAD)
-    XCTAssertEqual(Route.PATCH("/path").method, Moya.Method.PATCH)
-    XCTAssertEqual(Route.TRACE("/path").method, Moya.Method.TRACE)
-    XCTAssertEqual(Route.CONNECT("/path").method, Moya.Method.CONNECT)
+    XCTAssertEqual(Route.get("/path").method, Moya.Method.get)
+    XCTAssertEqual(Route.post("/path").method, Moya.Method.post)
+    XCTAssertEqual(Route.put("/path").method, Moya.Method.put)
+    XCTAssertEqual(Route.delete("/path").method, Moya.Method.delete)
+    XCTAssertEqual(Route.options("/path").method, Moya.Method.options)
+    XCTAssertEqual(Route.head("/path").method, Moya.Method.head)
+    XCTAssertEqual(Route.patch("/path").method, Moya.Method.patch)
+    XCTAssertEqual(Route.trace("/path").method, Moya.Method.trace)
+    XCTAssertEqual(Route.connect("/path").method, Moya.Method.connect)
   }
 
   func testRoutePath() {
-    XCTAssertEqual(Route.GET("/path").path, "/path")
-    XCTAssertEqual(Route.POST("/path").path, "/path")
-    XCTAssertEqual(Route.PUT("/path").path, "/path")
-    XCTAssertEqual(Route.DELETE("/path").path, "/path")
-    XCTAssertEqual(Route.OPTIONS("/path").path, "/path")
-    XCTAssertEqual(Route.HEAD("/path").path, "/path")
-    XCTAssertEqual(Route.PATCH("/path").path, "/path")
-    XCTAssertEqual(Route.TRACE("/path").path, "/path")
-    XCTAssertEqual(Route.CONNECT("/path").path, "/path")
+    XCTAssertEqual(Route.get("/path").path, "/path")
+    XCTAssertEqual(Route.post("/path").path, "/path")
+    XCTAssertEqual(Route.put("/path").path, "/path")
+    XCTAssertEqual(Route.delete("/path").path, "/path")
+    XCTAssertEqual(Route.options("/path").path, "/path")
+    XCTAssertEqual(Route.head("/path").path, "/path")
+    XCTAssertEqual(Route.patch("/path").path, "/path")
+    XCTAssertEqual(Route.trace("/path").path, "/path")
+    XCTAssertEqual(Route.connect("/path").path, "/path")
   }
 
 }

--- a/Tests/SugarTargetTypeTests.swift
+++ b/Tests/SugarTargetTypeTests.swift
@@ -30,13 +30,13 @@ class SugarTargetTypeTests: XCTestCase {
 
   func testMethod() {
     GitHubAPI.userRepos(owner: "devxoul").do {
-      XCTAssertEqual($0.method, .GET)
+      XCTAssertEqual($0.method, .get)
     }
     GitHubAPI.createIssue(owner: "devxoul", repo: "MoyaSugar", title: "Title", body: nil).do {
-      XCTAssertEqual($0.method, .POST)
+      XCTAssertEqual($0.method, .post)
     }
     GitHubAPI.editIssue(owner: "devxoul", repo: "Then", number: 1, title: "A", body: "B").do {
-      XCTAssertEqual($0.method, .PATCH)
+      XCTAssertEqual($0.method, .patch)
     }
   }
 


### PR DESCRIPTION
There is an **breaking change** in `Moya 8.0.0-beta.3` relating to `HTTP verbs enum`.
https://github.com/Moya/Moya/commit/76886247f32ff29e55ed86ff5f9913245fa98d62

I suggest this PR to correspond with latest tag of the `Moya`, so consider this if you want this repository to be up-to-date.
