### PR TITLE
Add support for customizing target's url

### DIFF
--- a/Sources/MoyaSugarProvider.swift
+++ b/Sources/MoyaSugarProvider.swift
@@ -24,7 +24,7 @@ open class MoyaSugarProvider<Target: SugarTargetType>: MoyaProvider<Target> {
     func sugarEndpointClosure(target: Target) -> Endpoint<Target> {
       let endpoint = endpointClosure(target)
       return Endpoint<Target>(
-        URL: endpoint.URL,
+        URL: target.url.absoluteString,
         sampleResponseClosure: endpoint.sampleResponseClosure,
         method: endpoint.method,
         parameters: endpoint.parameters,

--- a/Sources/RxSwift/RxMoyaSugarProvider.swift
+++ b/Sources/RxSwift/RxMoyaSugarProvider.swift
@@ -25,7 +25,7 @@ open class RxMoyaSugarProvider<Target: SugarTargetType>: RxMoyaProvider<Target> 
     func sugarEndpointClosure(target: Target) -> Endpoint<Target> {
       let endpoint = endpointClosure(target)
       return Endpoint<Target>(
-        URL: endpoint.URL,
+        URL: target.url.absoluteString,
         sampleResponseClosure: endpoint.sampleResponseClosure,
         method: endpoint.method,
         parameters: endpoint.parameters,

--- a/Sources/SugarTargetType.swift
+++ b/Sources/SugarTargetType.swift
@@ -50,6 +50,10 @@ public protocol SugarTargetType: TargetType {
 
 public extension SugarTargetType {
   public var url: URL {
+    return self.defaultURL
+  }
+
+  var defaultURL: URL {
     return self.baseURL.appendingPathComponent(self.path)
   }
 

--- a/Tests/GitHubAPI.swift
+++ b/Tests/GitHubAPI.swift
@@ -15,12 +15,16 @@ enum GitHubAPI: SugarTargetType, Then {
     return URL(string: "https://api.github.com")!
   }
 
+  case url(String)
   case userRepos(owner: String)
   case createIssue(owner: String, repo: String, title: String, body: String?)
   case editIssue(owner: String, repo: String, number: Int, title: String?, body: String?)
 
   var route: Route {
     switch self {
+    case .url(let urlString):
+      return .get(urlString)
+
     case .userRepos(let owner):
       return .get("/users/\(owner)/repos")
 
@@ -32,8 +36,20 @@ enum GitHubAPI: SugarTargetType, Then {
     }
   }
 
+  var url: URL {
+    switch self {
+    case .url(let urlString):
+      return URL(string: urlString)!
+    default:
+      return self.defaultURL
+    }
+  }
+
   var params: Parameters? {
     switch self {
+    case .url:
+      return nil
+
     case .userRepos:
       return nil
 

--- a/Tests/MoyaSugarProviderTests.swift
+++ b/Tests/MoyaSugarProviderTests.swift
@@ -25,6 +25,17 @@ fileprivate struct Endpoints<Target: SugarTargetType>: Then {
 class MoyaSugarProviderTests: XCTestCase {
 
   func testMoyaSugarProvider() {
+    GitHubAPI.url("https://api.github.com/user/devxoul/repos?page=2").do {
+      Endpoints($0).do {
+        XCTAssertEqual($0.moya.URL, "https://api.github.com/https://api.github.com/user/devxoul/repos%3Fpage=2")
+        XCTAssertEqual($0.sugar.URL, "https://api.github.com/user/devxoul/repos?page=2")
+        XCTAssertEqual($0.moya.method, $0.sugar.method)
+        XCTAssertEqual("\($0.moya.parameters)", "\($0.sugar.parameters)")
+        XCTAssertEqual($0.sugar.parameterEncoding is URLEncoding, true)
+        XCTAssertEqual($0.sugar.httpHeaderFields?["Accept"], "application/json")
+        XCTAssertEqual($0.sugar.httpHeaderFields?.count, 1)
+      }
+    }
     GitHubAPI.userRepos(owner: "devxoul").do {
       Endpoints($0).do {
         XCTAssertEqual($0.moya.URL, $0.sugar.URL)

--- a/Tests/SugarTargetTypeTests.swift
+++ b/Tests/SugarTargetTypeTests.swift
@@ -14,6 +14,9 @@ import MoyaSugar
 class SugarTargetTypeTests: XCTestCase {
 
   func testURL() {
+    GitHubAPI.url("https://github.com/user/devxoul/repos?page=2").do {
+      XCTAssertEqual($0.url, URL(string: "https://github.com/user/devxoul/repos?page=2")!)
+    }
     GitHubAPI.userRepos(owner: "devxoul").do {
       XCTAssertEqual($0.path, "/users/devxoul/repos")
       XCTAssertEqual($0.url, URL(string: "https://api.github.com/users/devxoul/repos")!)


### PR DESCRIPTION
## Summary

This PR provides an way to customize the target's url.

## Background

Imagine that we have an API which returns the next url path or url:

<pre>
{
  "data": [
    {...},
    {...},
    {...},
  ],
  <strong>"next": "/articles?page=2"</strong>
}
</pre>

In this case, we can add a case `path(String)`:

```swift
enum MyAPI: SugarTargetType {
  case path(String)
  case user(Int)

  var route: Route {
    switch self {
    case .path(let path):
      return .get(path)
    case .user(let id):
      return .get("/user/\(id)")
    }
  }
}
```

Default implementation of Moya uses `URL.appendingPathComponent(_:)` to make URL, so the URL will become `http://example.com/articles%3Fpage=2` (`?` becomes `%3F`)

## Customizing URL

With this PR, you'll be able to customize target URLs.

```swift
extension MyAPI: SugarTargetType {
  var url: URL {
    switch self {
    case .path:
      return URL(string: self.baseURL + self.path)! // custom url
    default:
      return self.defaultURL // default url
    }
  }
}
```
