### PR TITLE
Let EndpointClosure to override Target headers

### DIFF
--- a/Sources/MoyaSugarProvider.swift
+++ b/Sources/MoyaSugarProvider.swift
@@ -29,7 +29,7 @@ open class MoyaSugarProvider<Target: SugarTargetType>: MoyaProvider<Target> {
         method: endpoint.method,
         parameters: endpoint.parameters,
         parameterEncoding: endpoint.parameterEncoding,
-        httpHeaderFields: target.httpHeaderFields ?? endpoint.httpHeaderFields
+        httpHeaderFields: endpoint.httpHeaderFields ?? target.httpHeaderFields 
       )
     }
     super.init(


### PR DESCRIPTION
In my understanding, we use Endpoint closure in Moya to override some of the Target parameters. In MoyaSugar on the other hand, we override Endpoint defined headers with Target headers which to me seems wrong. For example, we have a Target that defines `Content-Type` and `Accept` headers 
```
var httpHeaderFields: [String : String]? {
    return ["Content-Type": "application/json",
            "Accept": "application/json"]
}
```
and use EndpointClosure to inject Authorization header - Target itself does not need to know, whether the user is authorized or not. So I define an EndpointClosure like so

```
let endpointClosure: ((MainApi) -> Endpoint<MainApi>) = { target in
    let url = target.baseURL.appendingPathComponent(target.path).absoluteString
            
    var headers = target.httpHeaderFields ?? [:]
    headers["Authorization"] = token
            
    return Endpoint(url: url, sampleResponseClosure: { .networkResponse(200, target.sampleData) },
                        method: target.method, parameters: target.parameters, httpHeaderFields: headers)
}
```

but then my headers get overwritten by SugarEndpointClosure. 

So in my opinion it's reasonable to use Endpoint provided headers and if there's none (as `MoyaProvider.defaultEndpointMapping` does not provide any headers) use Target defined ones